### PR TITLE
petsc fails to find mpiexec on mac

### DIFF
--- a/bluebrain/repo-bluebrain/packages/py-astrovascpy/package.py
+++ b/bluebrain/repo-bluebrain/packages/py-astrovascpy/package.py
@@ -11,12 +11,11 @@ class PyAstrovascpy(PythonPackage):
     Vasculature blood flow computation and impact of astrocytic
     endfeet on vessels
     """
-
-    homepage = "https://github.com/BlueBrain/AstroVascPy"
-    git = "https://github.com/BlueBrain/AstroVascPy.git"
+    homepage = "https://github.com/openbraininstitute/AstroVascPy"
+    git = "https://github.com/openbraininstitute/AstroVascPy.git"
     pypi = "AstroVascPy/AstroVascPy-0.1.5.tar.gz"
 
-    maintainers("tristan0x")
+    maintainers("cattabiani")
 
     version("0.1.5", sha256="9f444775f464de740590f8acd880caae87ca1ffdf7d524490d6b8ce21bb4d5af")
     version("0.1.2", tag="0.1.2")

--- a/var/spack/repos/builtin/packages/freetype/package.py
+++ b/var/spack/repos/builtin/packages/freetype/package.py
@@ -19,6 +19,7 @@ class Freetype(AutotoolsPackage, CMakePackage):
 
     maintainers("michaelkuhn")
 
+    version("2.13.3", sha256="5c3a8e78f7b24c20b25b54ee575d6daa40007a5f4eea2845861c3409b3021747")
     version("2.11.1", sha256="f8db94d307e9c54961b39a1cc799a67d46681480696ed72ecf78d4473770f09b")
     version("2.11.0", sha256="a45c6b403413abd5706f3582f04c8339d26397c4304b78fa552f2215df64101f")
     version("2.10.4", sha256="5eab795ebb23ac77001cfb68b7d4d50b5d6c7469247b0b01b2c953269f658dac")

--- a/var/spack/repos/builtin/packages/mpich/package.py
+++ b/var/spack/repos/builtin/packages/mpich/package.py
@@ -28,6 +28,7 @@ class Mpich(AutotoolsPackage, CudaPackage, ROCmPackage):
     keep_werror = "specific"
 
     version("develop", submodules=True)
+    version("4.2.3", sha256="7a019180c51d1738ad9c5d8d452314de65e828ee240bcb2d1f80de9a65be88a8")
     version("4.1.2", sha256="3492e98adab62b597ef0d292fb2459b6123bc80070a8aa0a30be6962075a12f0")
     version("4.1.1", sha256="ee30471b35ef87f4c88f871a5e2ad3811cd9c4df32fd4f138443072ff4284ca2")
     version("4.1", sha256="8b1ec63bc44c7caa2afbb457bc5b3cd4a70dbe46baba700123d67c48dc5ab6a0")
@@ -57,11 +58,13 @@ class Mpich(AutotoolsPackage, CudaPackage, ROCmPackage):
     variant("verbs", default=False, description="Build support for OpenFabrics verbs.")
     variant("slurm", default=False, description="Enable SLURM support")
     variant("wrapperrpath", default=True, description="Enable wrapper rpath")
+    # pmi=off is not an option anymore
+    # https://github.com/spack/spack/issues/42685
     variant(
         "pmi",
         default="pmi",
         description="""PMI interface.""",
-        values=("off", "pmi", "pmi2", "pmix", "cray"),
+        values=(conditional("off", when="@:4.1.1"), "pmi", "pmi2", "pmix", "cray"),
         multi=False,
     )
     variant(

--- a/var/spack/repos/builtin/packages/petsc/package.py
+++ b/var/spack/repos/builtin/packages/petsc/package.py
@@ -22,6 +22,7 @@ class Petsc(Package, CudaPackage, ROCmPackage):
 
     version("main", branch="main")
 
+    version("3.22.2", sha256="83624de0178b42d37ca1f7f905e1093556c6919fe5accd3e9f11d00a66e11256")
     version("3.20.1", sha256="3d54f13000c9c8ceb13ca4f24f93d838319019d29e6de5244551a3ec22704f32")
     version("3.20.0", sha256="c152ccb12cb2353369d27a65470d4044a0c67e0b69814368249976f5bb232bd4")
     version("3.19.6", sha256="6045e379464e91bb2ef776f22a08a1bc1ff5796ffd6825f15270159cbb2464ae")

--- a/var/spack/repos/builtin/packages/py-petsc4py/package.py
+++ b/var/spack/repos/builtin/packages/py-petsc4py/package.py
@@ -18,6 +18,7 @@ class PyPetsc4py(PythonPackage):
     maintainers("balay")
 
     version("main", branch="main")
+    version("3.22.2", sha256="6c56f62ae8819069062436d362a2cc7e44f700026eed72a903c3803afbe59fc3")
     version("3.20.1", sha256="dcc9092040d13130496f1961b79c36468f383b6ede398080e004f1966c06ad38")
     version("3.20.0", sha256="c2461eef3977ae5c214ad252520adbb92ec3a31d00e79391dd92535077bbf03e")
     version("3.19.6", sha256="bd7891b651eb83504c744e70706818cf63ecbabee3206c1fed7c3013873802b9")
@@ -73,7 +74,7 @@ class PyPetsc4py(PythonPackage):
     depends_on("petsc+mpi", when="+mpi")
     depends_on("petsc~mpi", when="~mpi")
     depends_on("petsc@main", when="@main")
-    for ver in ["3.20", "3.19", "3.18", "3.17", "3.16", "3.15", "3.13", "3.12", "3.11"]:
+    for ver in ["3.22", "3.20", "3.19", "3.18", "3.17", "3.16", "3.15", "3.13", "3.12", "3.11"]:
         depends_on(f"petsc@{ver}", when=f"@{ver}")
     depends_on("petsc@3.14.2:3.14", when="@3.14.1:3.14")
     depends_on("petsc@3.14.0:3.14.1", when="@3.14.0")


### PR DESCRIPTION
With this setup `petsc~hypre~superlu-dist` fails because it cannot find mpiexec (using mpich)
