### PR TITLE
py-astrovascpy, py-multiscale-run, freetype, py-mpi4py, py-numpy-quaternion, steps, sundials:

### DIFF
--- a/.github/workflows/validate-commit-message.yaml
+++ b/.github/workflows/validate-commit-message.yaml
@@ -7,6 +7,8 @@ on:
 jobs:
   validate:
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
     steps:
       - uses: actions/checkout@v3
         with:

--- a/bluebrain/repo-bluebrain/packages/py-astrovascpy/package.py
+++ b/bluebrain/repo-bluebrain/packages/py-astrovascpy/package.py
@@ -12,11 +12,11 @@ class PyAstrovascpy(PythonPackage):
     endfeet on vessels
     """
 
-    homepage = "https://github.com/BlueBrain/AstroVascPy"
-    git = "https://github.com/BlueBrain/AstroVascPy.git"
+    homepage = "https://github.com/openbraininstitute/AstroVascPy"
+    git = "https://github.com/openbraininstitute/AstroVascPy.git"
     pypi = "AstroVascPy/AstroVascPy-0.1.5.tar.gz"
 
-    maintainers("tristan0x")
+    maintainers("cattabiani")
 
     version("0.1.5", sha256="9f444775f464de740590f8acd880caae87ca1ffdf7d524490d6b8ce21bb4d5af")
     version("0.1.2", tag="0.1.2")

--- a/bluebrain/repo-bluebrain/packages/py-multiscale-run/package.py
+++ b/bluebrain/repo-bluebrain/packages/py-multiscale-run/package.py
@@ -10,9 +10,9 @@ class PyMultiscaleRun(PythonPackage):
     """BBP multiscale simulation orchestrator"""
 
     homepage = "https://github.com/BlueBrain/MultiscaleRun"
-    git = "ssh://git@bbpgitlab.epfl.ch/hpc/MultiscaleRun.git"
+    git = "git@github.com:openbraininstitute/MultiscaleRun.git"
 
-    maintainers("tristan0x", "cattabiani")
+    maintainers("cattabiani")
 
     version("develop", branch="main")
     version("0.8.1", tag="0.8.1")

--- a/bluebrain/repo-patches/packages/freetype/package.py
+++ b/bluebrain/repo-patches/packages/freetype/package.py
@@ -1,0 +1,9 @@
+from spack.package import *
+from spack.pkg.builtin.freetype import Freetype as BuiltinFreetype
+
+
+class Freetype(BuiltinFreetype):
+    __doc__ = BuiltinFreetype.__doc__
+
+    # they do not import Byte and on mac it fails with older versions
+    version("2.13.3", sha256="5c3a8e78f7b24c20b25b54ee575d6daa40007a5f4eea2845861c3409b3021747")

--- a/bluebrain/repo-patches/packages/py-mpi4py/package.py
+++ b/bluebrain/repo-patches/packages/py-mpi4py/package.py
@@ -1,0 +1,10 @@
+from spack.pkg.builtin.py_mpi4py import PyMpi4py as BuiltinPyMpi4py
+
+
+class PyMpi4py(BuiltinPyMpi4py):
+    __doc__ = BuiltinPyMpi4py.__doc__
+
+    def setup_build_environment(self, env):
+        # the shared is wrong on mac. Probably also in other cases.
+        # https://github.com/spack/spack/pull/41362
+        env.set("MPICC", self.spec["mpi"].mpicc)

--- a/bluebrain/repo-patches/packages/py-mpi4py/package.py
+++ b/bluebrain/repo-patches/packages/py-mpi4py/package.py
@@ -1,3 +1,4 @@
+from spack.package import *  # noqa: F401
 from spack.pkg.builtin.py_mpi4py import PyMpi4py as BuiltinPyMpi4py
 
 

--- a/bluebrain/repo-patches/packages/py-numpy-quaternion/package.py
+++ b/bluebrain/repo-patches/packages/py-numpy-quaternion/package.py
@@ -1,0 +1,11 @@
+from spack.package import conflicts, version
+from spack.pkg.builtin.py_numpy_quaternion import PyNumpyQuaternion as BuiltinPyNumpyQuaternion
+
+
+class PyNumpyQuaternion(BuiltinPyNumpyQuaternion):
+    __doc__ = BuiltinPyNumpyQuaternion.__doc__
+
+    version("2024.0.3", sha256="cf39a8a4506eeda297ca07a508c10c08b3487df851a0e34f070a7bf8fab9f290")
+
+    # numpy changed pointer types somewhere before at 1.26.1. Quaternion requires a newer verison
+    conflicts("py-numpy-quaternion@:2021.11.4.15.26.3", when="^py-numpy@1.26.1:")

--- a/bluebrain/repo-patches/packages/py-numpy-quaternion/package.py
+++ b/bluebrain/repo-patches/packages/py-numpy-quaternion/package.py
@@ -1,4 +1,4 @@
-from spack.package import conflicts, version
+from spack.package import *
 from spack.pkg.builtin.py_numpy_quaternion import PyNumpyQuaternion as BuiltinPyNumpyQuaternion
 
 

--- a/bluebrain/repo-patches/packages/steps/package.py
+++ b/bluebrain/repo-patches/packages/steps/package.py
@@ -12,9 +12,10 @@ class Steps(CMakePackage):
     """STochastic Engine for Pathway Simulation"""
 
     homepage = "https://groups.oist.jp/cnu/software"
-    git = "ssh://git@bbpgitlab.epfl.ch/hpc/HBP_STEPS.git"
+    # no https because the repo is not public
+    git = "git@github.com:CNS-OIST/HBP_STEPS.git"
 
-    maintainers("tristan0x")
+    maintainers("cattabiani")
 
     submodules = True
 

--- a/bluebrain/repo-patches/packages/sundials/package.py
+++ b/bluebrain/repo-patches/packages/sundials/package.py
@@ -1,0 +1,8 @@
+from spack.package import *
+from spack.pkg.builtin.sundials import Sundials as BuiltinSundials
+
+
+class Sundials(BuiltinSundials):
+    __doc__ = BuiltinSundials.__doc__
+    # required for building
+    depends_on("python", type="build")


### PR DESCRIPTION
py-astrovascpy: updated maintainer and repo
py-multiscale-run: updated maintainer and repo 
freetype: the base version fails to find the type `Byte`. The updated version has this problem fixed evidently
py-mpi4py: the `shared` is useless in linux systems and creates problems in mac. It was removed in future spack versions: https://github.com/spack/spack/pull/41362
py-numpy-quaternion: too old for our py-numpy version. A pointer type has changed in numpy. It needed an update - [x] steps: change repo as gitlab is no more
sundials: requires python at least for building. added dependency
deploy: `validate-commit-message` required permissions to let the CI run

**Why did I change these packages?**

First, we need to be able to develop. Without BB5 we need to turn to our personal laptops for development. This is the spack configuration for the moment paired with all the necessary changes to make it compile.

After much fighting I gave up on a `full-spack` installation. The current aim is to have a mixed brew-spack installation.

brew external pacakges:

```
brew install julia
brew install binutils
```
You also need to edit `~/.spack/packages.yaml`:

```
  julia:
    externals:
    - spec: julia@1.11.2
      prefix: /opt/homebrew/opt/julia
    buildable: false
  binutils:
    externals:
    - spec: binutils@2.43.1
      prefix: /opt/homebrew/opt/binutils
    buildable: false
```

`spack.yaml` in the spackenv:
```
# This is a Spack Environment file.
#
# It describes a set of packages to be installed, along with
# configuration settings.
spack:
  specs:
  - py-multiscale-run@develop
  packages:
    gmsh:
      require:
      - ~fltk    # Adds more load to compile
    petsc:
      require:
      - ~hypre~superlu-dist    # Hypre fails to compile, SuperLU the same
    # py-pandas:
    #   require: ~performance  # Otherwise pulls in numba that requires outdated LLVM
    py-numpy-quaternion:
      require: ~numba~scipy  # See above, get around Numba
    all:
      providers:
        mpi: [openmpi]

  view: true
  concretizer:
    unify: true
# this is for developing multiscale run
  develop:
    py-multiscale-run:
      path: /Users/katta/OBI/MultiscaleRun
      spec: py-multiscale-run@=develop
```

**Problems:**

- [x] petsc 3.20 does not install because it does not find `MPI_Finalize` -> use openmpi
- [x] libblastrampoline compilation hangs (julia dep) -> use brew to install julia