### PR TITLE
parquet-converters: connectome-manipulator fixes for the spacktainers

### DIFF
--- a/bluebrain/repo-bluebrain/packages/parquet-converters/package.py
+++ b/bluebrain/repo-bluebrain/packages/parquet-converters/package.py
@@ -9,8 +9,8 @@ from spack.package import *
 class ParquetConverters(CMakePackage):
     """Parquet conversion tools developed by Blue Brain Project, EPFL"""
 
-    homepage = "https://github.com/BlueBrain/parquet-converters"
-    git = "https://github.com/BlueBrain/parquet-converters.git"
+    homepage = "https://github.com/openbraininstitute/parquet-converters"
+    git = "https://github.com/openbraininstitute/parquet-converters.git"
 
     submodules = True
 

--- a/bluebrain/repo-bluebrain/packages/py-bluepysnap/package.py
+++ b/bluebrain/repo-bluebrain/packages/py-bluepysnap/package.py
@@ -23,7 +23,8 @@ class PyBluepysnap(PythonPackage):
 
     depends_on("python@3.8:", type=("build", "run"))
     depends_on("py-setuptools", type=("build", "run"))
-    depends_on("py-setuptools-scm@:8", type="build")
+    # It was pinned to :7. I do not know why. I try to remove it (Katta)
+    depends_on("py-setuptools-scm", type="build")
 
     depends_on("py-cached-property@1.0:", type=("build", "run"))
     depends_on("py-h5py@3.0.1:3", type=("build", "run"))

--- a/bluebrain/repo-bluebrain/packages/py-bluepysnap/package.py
+++ b/bluebrain/repo-bluebrain/packages/py-bluepysnap/package.py
@@ -10,7 +10,7 @@ class PyBluepysnap(PythonPackage):
     """Blue Brain SNAP is a Python library for accessing BlueBrain circuit models
     represented in SONATA format."""
 
-    homepage = "https://github.com/BlueBrain/snap"
+    homepage = "https://github.com/openbraininstitute/snap"
     pypi = "bluepysnap/bluepysnap-0.12.0.tar.gz"
 
     version("3.0.1", sha256="733bf35f90d11a70284793f0f0974fea628f70a47f16c4a200872ef75f36b597")
@@ -23,7 +23,7 @@ class PyBluepysnap(PythonPackage):
 
     depends_on("python@3.8:", type=("build", "run"))
     depends_on("py-setuptools", type=("build", "run"))
-    depends_on("py-setuptools-scm@:7", type="build")
+    depends_on("py-setuptools-scm@:8", type="build")
 
     depends_on("py-cached-property@1.0:", type=("build", "run"))
     depends_on("py-h5py@3.0.1:3", type=("build", "run"))

--- a/bluebrain/repo-patches/packages/boost/package.py
+++ b/bluebrain/repo-patches/packages/boost/package.py
@@ -1,0 +1,25 @@
+from spack.package import *
+from spack.pkg.builtin.boost import Boost as BuiltinBoost
+
+
+class Boost(BuiltinBoost):
+    __doc__ = BuiltinBoost.__doc__
+
+    version("1.87.0", sha256="af57be25cb4c4f4b413ed692fe378affb4352ea50fbe294a11ef548f4d527d89")
+
+    variant(
+        "cxxstd",
+        default="98",
+        values=(
+            conditional("98", when="@:1.83.0"),
+            "11",
+            "14",
+            conditional("17", when="@1.63.0:"),
+            conditional("2a", when="@1.73.0:"),
+            conditional("20", when="@1.77.0:"),
+            conditional("23", when="@1.79.0:"),
+            conditional("26", when="@1.79.0:"),
+        ),
+        multi=False,
+        description="Use the specified C++ standard when building.",
+    )

--- a/var/spack/repos/builtin/packages/py-morph-tool/package.py
+++ b/var/spack/repos/builtin/packages/py-morph-tool/package.py
@@ -9,7 +9,7 @@ from spack.package import *
 class PyMorphTool(PythonPackage):
     """Python morphology manipulation toolkit"""
 
-    homepage = "https://github.com/BlueBrain/morph-tool"
+    homepage = "https://github.com/openbraininstitute/morph-tool"
     git = "https://github.com/BlueBrain/morph-tool.git"
     pypi = "morph-tool/morph-tool-2.9.1.tar.gz"
 
@@ -22,7 +22,7 @@ class PyMorphTool(PythonPackage):
     variant("parallel", default=False, description="Enable additional parallel support")
 
     depends_on("py-setuptools", type="build")
-    depends_on("py-setuptools-scm@:7", type="build")
+    depends_on("py-setuptools-scm@:8", type="build")
 
     depends_on("py-click@6.7:", type=("build", "run"))
     depends_on("py-deprecation@2.1.0:", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-morph-tool/package.py
+++ b/var/spack/repos/builtin/packages/py-morph-tool/package.py
@@ -22,7 +22,8 @@ class PyMorphTool(PythonPackage):
     variant("parallel", default=False, description="Enable additional parallel support")
 
     depends_on("py-setuptools", type="build")
-    depends_on("py-setuptools-scm@:8", type="build")
+    # It was pinned to :7. I do not know why. I try to remove it (Katta)
+    depends_on("py-setuptools-scm", type="build")
 
     depends_on("py-click@6.7:", type=("build", "run"))
     depends_on("py-deprecation@2.1.0:", type=("build", "run"))


### PR DESCRIPTION
- parquet-converters: update to OBI
- boost: bump and improve default variant
- py-bluepysnap: unpin py-setuptools-scm
- py-morph-tool: unpin py-setuptools-scm