### PR TITLE
meson, neuron: fixes for neurodamus_models

### DIFF
--- a/bluebrain/repo-patches/packages/meson/package.py
+++ b/bluebrain/repo-patches/packages/meson/package.py
@@ -5,4 +5,6 @@ from spack.pkg.builtin.meson import Meson as BuiltinMeson
 class Meson(BuiltinMeson):
     __doc__ = BuiltinMeson.__doc__
 
+    version("1.4.0", sha256="61382f295378bddcd9bebb3a9a9065b1cbc671fa41b80964ab02726f9a5f3a88")
+
     patch("pgmath.patch", when="target=aarch64:")

--- a/bluebrain/repo-patches/packages/neuron/package.py
+++ b/bluebrain/repo-patches/packages/neuron/package.py
@@ -181,7 +181,7 @@ class Neuron(BuiltinNeuron):
         # and in particular -ffinite-math-only is enough to set it on or they are compatible.
         # If set the flags from here to ffp=strict theya re overridden in neuron and the problems
         # still appears. This should be fixed in neuron itself
-        # TODO: link issue once done
+        # https://github.com/neuronsimulator/nrn/issues/3504
         if self.compiler.name == "clang":
             args.append(self.define("NRN_ENABLE_MATH_OPT", False))
         return args

--- a/bluebrain/repo-patches/packages/neuron/package.py
+++ b/bluebrain/repo-patches/packages/neuron/package.py
@@ -174,6 +174,16 @@ class Neuron(BuiltinNeuron):
             host_compiler = host_compiler_candidates[0]
             args.append(self.define("CMAKE_CUDA_HOST_COMPILER", host_compiler.cxx))
 
+        # Here we added some FENV_ACCESS calls: https://github.com/neuronsimulator/nrn/pull/2856
+        # This is a workaround for llvm clang because FENV_ACCESS ON is not allowed if the math is
+        # not at least "precise". In gcc this line in neuron: `set(UNSAFE_MATH_FLAG
+        # "-ffinite-math-only -fno-math-errno -funsafe-math-optimizations -fno-associative-math")`
+        # and in particular -ffinite-math-only is enough to set it on or they are compatible.
+        # If set the flags from here to ffp=strict theya re overridden in neuron and the problems
+        # still appears. This should be fixed in neuron itself
+        # TODO: link issue once done
+        if self.compiler.name == "clang":
+            args.append(self.define("NRN_ENABLE_MATH_OPT", False))
         return args
 
     def setup_run_environment(self, env):


### PR DESCRIPTION
meson: 1.2.2 had a typo in the linker search for clang. 1.4 has this fixed. Bump version
neuron: FENV_ACCESS ON is not allowed when math is not precise. -ffinite-math-only is
	enough for gcc to make it ON without complaining. For clang we need to specify
        at least ffp: precise to the compiler. However, doing this from spack is not
        possible because when we set -ffinite-math-only in neuron we override. As a
        workaround we set NRN_ENABLE_MATH_OPT=OFF for now.