### PR TITLE
neuron: shipped fmt conflicts with other fmts required by other packages

### DIFF
--- a/bluebrain/repo-patches/packages/neuron/package.py
+++ b/bluebrain/repo-patches/packages/neuron/package.py
@@ -15,6 +15,7 @@ class Neuron(BuiltinNeuron):
     submodules = True
 
     # BBP specific version
+    version("base", branch="master")
     version("develop", branch="master")
     version("9.0.a19", commit="7175203")
     version("9.0.a18", commit="942d5ef")
@@ -187,11 +188,6 @@ class Neuron(BuiltinNeuron):
             args.append(self.define("NRN_ENABLE_MATH_OPT", False))
 
         # Inject fmt paths from Spack spec
-        fmt_spec = spec["fmt"]
-        args.append(self.define("FMT_LIB_DIR", fmt_spec.prefix.lib))
-        args.append(self.define("FMT_INC_DIR", fmt_spec.prefix.include))
-        args.append(self.define("FMT_PKGCONFIG_DIR", fmt_spec.prefix.lib.pkgconfig))
-        args.append(self.define("FMT_CMAKE_DIR", fmt_spec.prefix.lib.cmake.fmt))
         return args
 
     def setup_run_environment(self, env):

--- a/bluebrain/repo-patches/packages/neuron/package.py
+++ b/bluebrain/repo-patches/packages/neuron/package.py
@@ -185,6 +185,13 @@ class Neuron(BuiltinNeuron):
         # https://github.com/neuronsimulator/nrn/issues/3504
         if self.compiler.name == "clang":
             args.append(self.define("NRN_ENABLE_MATH_OPT", False))
+
+        # Inject fmt paths from Spack spec
+        fmt_spec = spec['fmt']
+        args.append(self.define("FMT_LIB_DIR", fmt_spec.prefix.lib))
+        args.append(self.define("FMT_INC_DIR", fmt_spec.prefix.include))
+        args.append(self.define("FMT_PKGCONFIG_DIR", fmt_spec.prefix.lib.pkgconfig))
+        args.append(self.define("FMT_CMAKE_DIR", fmt_spec.prefix.lib.cmake.fmt))
         return args
 
     def setup_run_environment(self, env):

--- a/bluebrain/repo-patches/packages/neuron/package.py
+++ b/bluebrain/repo-patches/packages/neuron/package.py
@@ -187,7 +187,7 @@ class Neuron(BuiltinNeuron):
             args.append(self.define("NRN_ENABLE_MATH_OPT", False))
 
         # Inject fmt paths from Spack spec
-        fmt_spec = spec['fmt']
+        fmt_spec = spec["fmt"]
         args.append(self.define("FMT_LIB_DIR", fmt_spec.prefix.lib))
         args.append(self.define("FMT_INC_DIR", fmt_spec.prefix.include))
         args.append(self.define("FMT_PKGCONFIG_DIR", fmt_spec.prefix.lib.pkgconfig))


### PR DESCRIPTION
try to force neuron to use the spack-supplied one