### PR TITLE
py-neurodamus: bump py-neurodamus version 

### DIFF
--- a/bluebrain/repo-bluebrain/packages/py-neurodamus/package.py
+++ b/bluebrain/repo-bluebrain/packages/py-neurodamus/package.py
@@ -13,6 +13,7 @@ class PyNeurodamus(PythonPackage):
     pypi = "neurodamus/neurodamus-3.1.1.tar.gz"
 
     version("develop", branch="main")
+    version("3.10.0", sha256="7ae17ca8ba86abb457dbecbc841eac29dcccb0b4a6a03fff98bb02da15d6aea8")
     version("3.9.0", sha256="eef43faf7dcbf8142bcd705d486542f571273beef87c1ee8b365ce8e291297cb")
     version("3.8.0", sha256="aef1f5ea44d69e7191d484d37b377941b361e601de9283b96711c4408901a97c")
     version("3.7.2", sha256="f2001b6807921a87b83ae041b7540a63dbb428eae81eae933fd14c788975f304")


### PR DESCRIPTION
py-neurodamus: 3.10.0 version of py-neurodamus has been released.